### PR TITLE
Simplify API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "sudokugen"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sudokugen"
 description = "Sudokugen is a sudoku solving and generating library"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Vasco Fernandes <vasco.box@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/benches/solve.rs
+++ b/benches/solve.rs
@@ -1,16 +1,26 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use sudokugen::generate;
-use sudokugen::solve;
-fn solve_benchmark(c: &mut Criterion) {
-    let table = ".724..3........49.........2921...5.7..4.6...3......2...4..7.....3..196....5..4.21"
-        .parse()
-        .unwrap();
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 
-    c.bench_function("solve", |b| b.iter(|| solve(black_box(&table)).unwrap()));
+use sudokugen::{board::BoardSize, Board, Puzzle};
+
+fn solve_benchmark(c: &mut Criterion) {
+    let table: Board =
+        ".724..3........49.........2921...5.7..4.6...3......2...4..7.....3..196....5..4.21"
+            .parse()
+            .unwrap();
+
+    c.bench_function("solve", |b| {
+        b.iter_batched(
+            || table.clone(),
+            |mut table| table.solve(),
+            BatchSize::SmallInput,
+        )
+    });
 }
 
 fn generate_benchmark(c: &mut Criterion) {
-    c.bench_function("generate", |b| b.iter(|| generate(black_box(3))));
+    c.bench_function("generate", |b| {
+        b.iter(|| Puzzle::generate(black_box(BoardSize::NineByNine)))
+    });
 }
 
 criterion_group!(solve_bench, solve_benchmark);

--- a/src/board.rs
+++ b/src/board.rs
@@ -302,12 +302,10 @@ impl Board {
     /// ```
     #[must_use]
     pub fn new(base_size: usize) -> Self {
-        let table = Board {
+        Board {
             base_size,
             cells: vec![None; base_size.pow(4)],
-        };
-
-        table
+        }
     }
 
     /// Returns the base size of this board, check the documentation of [`new`] for an

--- a/src/board.rs
+++ b/src/board.rs
@@ -7,11 +7,6 @@
 //! the [`CellLoc`] structure to reference a location in the board, but
 //! the [`cell_at`] method of the board instance is more convenient to address
 //! cells of a specific board.
-//!
-//! [`Board`]: struct.Board.html
-//! [`new`]: struct.Board.html#method.new
-//! [`CellLoc`]: struct.CellLoc.html
-//! [`cell_at`]: struct.Board.html#method.cell_at
 
 use std::collections::BTreeSet;
 use std::convert::TryInto;
@@ -19,13 +14,68 @@ use std::error;
 use std::fmt;
 use std::str::FromStr;
 
+use error::Error;
+use fmt::Display;
+
+/// Represents the size of the board that sudukogen can work with.
+/// Currently only 4x4, 9x9, and 16x16 boards are allowed.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum BoardSize {
+    /// A board with 16 cells, in a 4 by 4 square
+    FourByFour,
+    /// A board with 81 cells, in a 9 by 9 square
+    NineByNine,
+    /// A board with 337 cells, in a 16 by 16 square
+    SixteenBySixteen,
+}
+
+impl BoardSize {
+    /// A sudoku board is a square of N by N squares, each of them composed of N by N cells
+    /// the base size of a board is N. For instance in a 9 by 9 board, composed of 3 by 3 squares,
+    /// each of them composed of 3 by 3 cells, the base size is 3.
+    pub fn get_base_size(&self) -> usize {
+        match self {
+            Self::FourByFour => 2,
+            Self::NineByNine => 3,
+            Self::SixteenBySixteen => 4,
+        }
+    }
+}
+
+/// Error returned when a `base_size: usize` cannot be converted to a board size,
+/// currently only 2, 3, and 4 can be converted back to a board size.
+#[derive(Debug)]
+pub struct BoardSizeOutOfRangeError(usize);
+impl Display for BoardSizeOutOfRangeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!(
+            "Board size is out of range, {} is not an accepted base size for a board",
+            self.0,
+        ))
+    }
+}
+impl Error for BoardSizeOutOfRangeError {}
+
+impl TryInto<BoardSize> for usize {
+    type Error = BoardSizeOutOfRangeError;
+
+    fn try_into(self) -> Result<BoardSize, Self::Error> {
+        match self {
+            2 => Ok(BoardSize::FourByFour),
+            3 => Ok(BoardSize::NineByNine),
+            4 => Ok(BoardSize::SixteenBySixteen),
+            _ => Err(BoardSizeOutOfRangeError(self)),
+        }
+    }
+}
+
 /// Represents a sudoku board.
 ///
 /// This is usually the entry point to use any of the functionality in this library.
-/// You can create a new board by simply calling new and specifying the base size of the board.
+/// You can create a new board by simply calling new and specifying the size of the board.
 /// ```
-/// use sudokugen::board::Board;
-/// let board: Board = Board::new(3);
+/// use sudokugen::{Board, BoardSize};
+/// let board: Board = Board::new(BoardSize::NineByNine);
 /// ```
 ///
 /// Or you can parse an existing representation of a board using the [`from_str`] method of the [`FromStr`] trait.
@@ -61,7 +111,7 @@ pub struct Board {
 ///
 /// CellLoc structures are a shallow
 /// abstraction of the indice of the cell in the board, using them allows access
-/// helper functions to navigate the board and access cell by a more intuitive
+/// helper functions to navigate the board and access each cell by a more intuitive
 /// line/column pair
 pub struct CellLoc {
     base_size: usize,
@@ -82,18 +132,19 @@ impl fmt::Debug for CellLoc {
 
 impl CellLoc {
     /// Returns a cell representing the location at line `l` and column `c`.
-    /// The third argument represents the intrinsic size of the board, for a
-    /// regular 9 by 9 board the base size is 3 (i.e. sqrt(9))
+    /// The third argument represents the size of the board.
     ///
     /// ```
+    /// use sudokugen::BoardSize;
     /// use sudokugen::board::CellLoc;
     ///
-    /// let cell = CellLoc::at(0, 0, 3);
+    /// let cell = CellLoc::at(0, 0, BoardSize::NineByNine);
     /// assert_eq!(cell.line(), 0);
     /// assert_eq!(cell.col(), 0);
     /// ```
     ///
-    pub fn at(l: usize, c: usize, base_size: usize) -> Self {
+    pub fn at(l: usize, c: usize, board_size: BoardSize) -> Self {
+        let base_size = board_size.get_base_size();
         CellLoc {
             idx: l * base_size.pow(2) + c,
             base_size,
@@ -101,25 +152,27 @@ impl CellLoc {
     }
 
     /// Reference a new location in the board. `idx` is the 0 based flat ordering of all cells
-    /// in the board and base_size is the intrinsic size of the board, for a
-    /// regular 9 by 9 board the base size is 3 (i.e. sqrt(9)).
+    /// in the board.
     ///
     /// ```
     /// use sudokugen::board::CellLoc;
+    /// use sudokugen::BoardSize;
     ///
-    /// let cell = CellLoc::new(9, 3);
+    /// let cell = CellLoc::new(9, BoardSize::NineByNine);
     /// assert_eq!((cell.line(), cell.col()), (1, 0));
     /// ```
-    pub fn new(idx: usize, base_size: usize) -> Self {
+    pub fn new(idx: usize, board_size: BoardSize) -> Self {
+        let base_size = board_size.get_base_size();
         CellLoc { idx, base_size }
     }
 
     /// Returns the 0 based flat index of this cell location
     ///
     /// ```
+    /// use sudokugen::BoardSize;
     /// use sudokugen::board::CellLoc;
     ///
-    /// let cell = CellLoc::new(9, 3);
+    /// let cell = CellLoc::new(9, BoardSize::NineByNine);
     /// assert_eq!(cell.get_index(), 9);
     /// ```
     pub fn get_index(&self) -> usize {
@@ -132,9 +185,9 @@ impl CellLoc {
     ///
     /// ```
     /// use sudokugen::board::CellLoc;    
-    /// use sudokugen::board::Board;
+    /// use sudokugen::{Board, BoardSize};
     ///
-    /// let cell = CellLoc::at(0, 1, 2);
+    /// let cell = CellLoc::at(0, 1, BoardSize::FourByFour);
     /// let board: Board = "
     /// 1 . | . .
     /// . . | . .
@@ -173,8 +226,9 @@ impl CellLoc {
     ///
     /// ```
     /// use sudokugen::board::CellLoc;
+    /// use sudokugen::BoardSize;
     ///
-    /// let cell = CellLoc::at(0, 0, 3);
+    /// let cell = CellLoc::at(0, 0, BoardSize::NineByNine);
     /// assert_eq!(cell.line(), 0);
     /// ```
     pub fn line(&self) -> usize {
@@ -184,9 +238,10 @@ impl CellLoc {
     /// Returns the 0 based column number for this cell location
     ///
     /// ```
+    /// use sudokugen::BoardSize;
     /// use sudokugen::board::CellLoc;
     ///
-    /// let cell = CellLoc::at(0, 0, 3);
+    /// let cell = CellLoc::at(0, 0, BoardSize::NineByNine);
     /// assert_eq!(cell.col(), 0);
     /// ```
     pub fn col(&self) -> usize {
@@ -197,9 +252,10 @@ impl CellLoc {
     /// Squares are numbered line first and then columns.
     ///
     /// ```
+    /// use sudokugen::BoardSize;
     /// use sudokugen::board::CellLoc;
     ///
-    /// let cell = CellLoc::at(4, 3, 3);
+    /// let cell = CellLoc::at(4, 3, BoardSize::NineByNine);
     /// assert_eq!(cell.square(), 4);
     /// ```
     pub fn square(&self) -> usize {
@@ -213,15 +269,16 @@ impl CellLoc {
     ///
     /// ```
     /// use sudokugen::board::CellLoc;
+    /// use sudokugen::BoardSize;
     ///
-    /// let cell = CellLoc::at(0, 0, 2);
+    /// let cell = CellLoc::at(0, 0, BoardSize::FourByFour);
     /// assert_eq!(
     ///     cell.iter_line().collect::<Vec<CellLoc>>(),
     ///     vec![
-    ///         CellLoc::at(0, 0, 2),
-    ///         CellLoc::at(0, 1, 2),
-    ///         CellLoc::at(0, 2, 2),
-    ///         CellLoc::at(0, 3, 2),
+    ///         CellLoc::at(0, 0, BoardSize::FourByFour),
+    ///         CellLoc::at(0, 1, BoardSize::FourByFour),
+    ///         CellLoc::at(0, 2, BoardSize::FourByFour),
+    ///         CellLoc::at(0, 3, BoardSize::FourByFour),
     ///     ]
     ///);
     pub fn iter_line(&self) -> impl Iterator<Item = CellLoc> {
@@ -237,15 +294,16 @@ impl CellLoc {
     ///
     /// ```
     /// use sudokugen::board::CellLoc;
+    /// use sudokugen::BoardSize;
     ///
-    /// let cell = CellLoc::at(0, 0, 2);
+    /// let cell = CellLoc::at(0, 0, BoardSize::FourByFour);
     /// assert_eq!(
     ///     cell.iter_col().collect::<Vec<CellLoc>>(),
     ///     vec![
-    ///         CellLoc::at(0, 0, 2),
-    ///         CellLoc::at(1, 0, 2),
-    ///         CellLoc::at(2, 0, 2),
-    ///         CellLoc::at(3, 0, 2),
+    ///         CellLoc::at(0, 0, BoardSize::FourByFour),
+    ///         CellLoc::at(1, 0, BoardSize::FourByFour),
+    ///         CellLoc::at(2, 0, BoardSize::FourByFour),
+    ///         CellLoc::at(3, 0, BoardSize::FourByFour),
     ///     ]
     ///);
     pub fn iter_col(&self) -> impl Iterator<Item = CellLoc> {
@@ -261,15 +319,16 @@ impl CellLoc {
     ///
     /// ```
     /// use sudokugen::board::CellLoc;
+    /// use sudokugen::BoardSize;
     ///
-    /// let cell = CellLoc::at(0, 0, 2);
+    /// let cell = CellLoc::at(0, 0, BoardSize::FourByFour);
     /// assert_eq!(
     ///     cell.iter_square().collect::<Vec<CellLoc>>(),
     ///     vec![
-    ///         CellLoc::at(0, 0, 2),
-    ///         CellLoc::at(0, 1, 2),
-    ///         CellLoc::at(1, 0, 2),
-    ///         CellLoc::at(1, 1, 2),
+    ///         CellLoc::at(0, 0, BoardSize::FourByFour),
+    ///         CellLoc::at(0, 1, BoardSize::FourByFour),
+    ///         CellLoc::at(1, 0, BoardSize::FourByFour),
+    ///         CellLoc::at(1, 1, BoardSize::FourByFour),
     ///     ]
     ///);
     pub fn iter_square(&self) -> impl Iterator<Item = CellLoc> {
@@ -291,36 +350,31 @@ impl CellLoc {
 }
 
 impl Board {
-    /// Creates a new empty board. The `base_size` parameter represents the size
-    /// of the board, base size is the square root of the the width of the board.
-    /// so for instance a 9x9 board has a base size of 3, a 16x16 board has a base size
-    /// of 4, etc.
+    /// Creates a new empty board of the specified size.
     ///
     /// ```
-    /// use sudokugen::board::Board;
-    /// let board: Board = Board::new(3);
+    /// use sudokugen::{Board, BoardSize};
+    ///
+    /// let board: Board = Board::new(BoardSize::NineByNine);
     /// ```
     #[must_use]
-    pub fn new(base_size: usize) -> Self {
+    pub fn new(board_size: BoardSize) -> Self {
+        let base_size = board_size.get_base_size();
         Board {
             base_size,
             cells: vec![None; base_size.pow(4)],
         }
     }
 
-    /// Returns the base size of this board, check the documentation of [`new`] for an
-    /// explanation of base size.
-    ///
-    /// [`new`]: #method.new
-    ///
+    /// Returns the board size of this board..
     /// ```
-    /// use sudokugen::board::Board;
-    /// let board: Board = Board::new(3);
+    /// use sudokugen::{Board, BoardSize};
+    /// let board: Board = Board::new(BoardSize::NineByNine);
     ///
-    /// assert_eq!(board.get_base_size(), 3);
+    /// assert_eq!(board.board_size(), BoardSize::NineByNine);
     /// ```
-    pub fn get_base_size(&self) -> usize {
-        self.base_size
+    pub fn board_size(&self) -> BoardSize {
+        self.base_size.try_into().unwrap()
     }
 
     /// Sets the value of a cell in the board using the [`CellLoc`] structure
@@ -329,11 +383,11 @@ impl Board {
     /// [`CellLoc`]: struct.CellLoc.html
     ///
     /// ```
-    /// use sudokugen::board::Board;
+    /// use sudokugen::{Board, BoardSize};
     /// use sudokugen::board::CellLoc;
     ///
-    /// let mut board = Board::new(3);
-    /// let cell = CellLoc::at(0, 0, 3);
+    /// let mut board = Board::new(BoardSize::NineByNine);
+    /// let cell = CellLoc::at(0, 0, BoardSize::NineByNine);
     /// board.set(&cell, 1);
     ///
     /// assert_eq!(board.get(&cell), Some(1));
@@ -346,25 +400,27 @@ impl Board {
     /// Returns the previous value in the board.
     ///
     /// ```
-    /// use sudokugen::board::Board;
+    /// use sudokugen::{Board, BoardSize};
     ///
-    /// let mut board = Board::new(3);
+    /// let mut board = Board::new(BoardSize::NineByNine);
     /// board.set_at(0, 0, 1);
     ///
     /// assert_eq!(board.get_at(0, 0), Some(1));
     /// ```
     pub fn set_at(&mut self, l: usize, c: usize, value: u8) -> Option<u8> {
-        self.cells[CellLoc::at(l, c, self.base_size).get_index()].replace(value)
+        let board_size = self.board_size();
+
+        self.cells[CellLoc::at(l, c, board_size).get_index()].replace(value)
     }
 
     /// Remove a value from the board at this cell and return the previously saved value.
     ///
     /// ```
-    /// use sudokugen::board::Board;
+    /// use sudokugen::{Board, BoardSize};    
     /// use sudokugen::board::CellLoc;
     ///
     /// let mut board: Board = "1... .... .... ....".parse().unwrap();
-    /// let cell = CellLoc::at(0, 0, 2);
+    /// let cell = CellLoc::at(0, 0, BoardSize::FourByFour);
     ///
     /// let old_value = board.unset(&cell);
     ///
@@ -406,21 +462,24 @@ impl Board {
     /// assert_eq!(board.get_at(0, 1), None);
     /// ```
     pub fn get_at(&self, l: usize, c: usize) -> Option<u8> {
-        self.get(&CellLoc::at(l, c, self.base_size))
+        self.get(&CellLoc::at(l, c, self.board_size()))
     }
 
     /// Return an iterator over all cells in the board.
     ///
     /// ```
-    /// use sudokugen::board::Board;
+    /// use sudokugen::{Board, BoardSize};
     /// use sudokugen::board::CellLoc;
     /// use std::collections::BTreeSet;
     ///
-    /// let board = Board::new(2);
+    /// let board = Board::new(BoardSize::FourByFour);
     ///
     /// assert_eq!(
     ///     board.iter_cells().collect::<BTreeSet<CellLoc>>(),
-    ///     (0..4).flat_map(|line| (0..4).map(move |col| CellLoc::at(line.clone(), col, 2))).collect::<BTreeSet<CellLoc>>()
+    ///     (0..4).flat_map(|line| (0..4).map(move |col| {
+    ///         CellLoc::at(line.clone(), col, BoardSize::FourByFour)
+    ///     }))
+    ///         .collect::<BTreeSet<CellLoc>>()
     /// );
     /// ```
     ///
@@ -441,9 +500,9 @@ impl Board {
     /// line and column using the [`at`] method
     ///
     /// ```
-    /// use sudokugen::board::Board;
+    /// use sudokugen::{Board, BoardSize};
     ///
-    /// let board = Board::new(3);
+    /// let board = Board::new(BoardSize::NineByNine);
     /// let cell = board.cell_at(1, 1);
     ///
     /// assert_eq!((cell.line(), cell.col()), (1, 1));
@@ -453,10 +512,10 @@ impl Board {
     /// [`at`]: struct.CellLoc.html#at
     #[must_use]
     pub fn cell_at(&self, l: usize, c: usize) -> CellLoc {
-        CellLoc::at(l, c, self.base_size)
+        CellLoc::at(l, c, self.board_size())
     }
 
-    /// Returns a new sudoku [`board`] rotated clockwise by 90deg.
+    /// Returns a new sudoku [`Board`] rotated clockwise by 90deg.
     ///
     /// Valid sudoku puzzles are also valid if rotated 90deg, 180deg and 270deg,
     /// they are the same puzzle, however must people would have trouble realizing that
@@ -485,10 +544,9 @@ impl Board {
     ///
     /// assert_eq!(board.rotated(), rotated_board);
     /// ```
-    ///
-    // [`board`]: #
+
     pub fn rotated(&self) -> Self {
-        let mut board = Board::new(self.base_size);
+        let mut board = Board::new(self.board_size());
         let width = self.base_size.pow(2);
 
         for cell in self.iter_cells() {
@@ -601,14 +659,19 @@ impl FromStr for Board {
             return Err(MalformedBoardError);
             // panic!("String definition of board does not have the correct size")
         }
-        let mut table = Board::new(base_size as usize);
+
+        let board_size: BoardSize = (base_size as usize)
+            .try_into()
+            .map_err(|_| MalformedBoardError)?;
+
+        let mut table = Board::new(board_size);
 
         // TODO: must support deserialization of tables larger than base 3
         for (idx, c) in board_as_string.char_indices() {
             match c {
                 '1'..='9' => {
                     table.set(
-                        &CellLoc::new(idx, base_size as usize),
+                        &CellLoc::new(idx, board_size),
                         c.to_digit(10).unwrap().try_into().unwrap(),
                     );
                 }
@@ -623,35 +686,35 @@ impl FromStr for Board {
 
 #[cfg(test)]
 mod test {
-    use super::Board;
     use super::CellLoc;
+    use super::{Board, BoardSize};
     use std::collections::BTreeSet;
 
     #[test]
     fn basics() {
-        let table = Board::new(2);
+        let table = Board::new(BoardSize::FourByFour);
 
         assert!(table.iter_cells().all(|cell| table.get(&cell).is_none()));
     }
 
     #[test]
     fn set_value() {
-        let mut table = Board::new(3);
+        let mut table = Board::new(BoardSize::NineByNine);
         assert_eq!(table.get_at(0, 0), None);
-        table.set(&CellLoc::new(0, 3), 3);
+        table.set(&CellLoc::new(0, BoardSize::NineByNine), 3);
         assert_eq!(table.get_at(0, 0), Some(3));
     }
 
     #[test]
     fn square() {
-        assert_eq!(CellLoc::at(0, 0, 3).square(), 0);
-        assert_eq!(CellLoc::at(0, 3, 3).square(), 1);
-        assert_eq!(CellLoc::at(3, 0, 3).square(), 3);
+        assert_eq!(CellLoc::at(0, 0, BoardSize::NineByNine).square(), 0);
+        assert_eq!(CellLoc::at(0, 3, BoardSize::NineByNine).square(), 1);
+        assert_eq!(CellLoc::at(3, 0, BoardSize::NineByNine).square(), 3);
     }
 
     #[test]
     fn iter_cells() {
-        let table = Board::new(3);
+        let table = Board::new(BoardSize::NineByNine);
         assert_eq!(
             table
                 .iter_cells()
@@ -679,7 +742,7 @@ mod test {
 
     #[test]
     fn possible_values_is_zero() {
-        let mut table = Board::new(3);
+        let mut table = Board::new(BoardSize::NineByNine);
         table.set_at(0, 0, 1);
 
         let mut iter = table.iter_cells();
@@ -691,7 +754,7 @@ mod test {
 
     #[test]
     fn possible_values() {
-        let mut table = Board::new(3);
+        let mut table = Board::new(BoardSize::NineByNine);
         table.set_at(0, 1, 2);
         table.set_at(0, 2, 3);
         table.set_at(1, 0, 4);
@@ -715,6 +778,6 @@ mod test {
     fn from() {
         let table: Board = "................".parse().unwrap();
         print!("{}", table);
-        assert_eq!(table, Board::new(2));
+        assert_eq!(table, Board::new(BoardSize::FourByFour));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,9 @@
 //! This library was built as a rust learning project for myself.
 //!
 //! # How to use Sudokugen
-//! Sudokugen offers two convenience functions, [`solve`] and [`generate`] to solve and generate
-//! sudoku puzzles and a struct [`Board`] to help you inspect and manipulate them.
+//! Sudokugen two structures to parse, manipulate and display sudoku board and puzzles.
+//! The [Board] structure allows you to parse a board from a string, display it and try to solve it.
+//! The [Puzzle] strucutre contains the information relevant for a new puzzle, the initial board and it's solution.
 //!
 //! You can parse a puzzle from a string:
 //!
@@ -27,12 +28,11 @@
 //!      . . . | 7 2 . | 6 . .
 //! ".parse().unwrap();
 //! ```
-//! After it's parsed you can solve it using the [`solve`] function:
+//! After it's parsed you can solve it using the [Board::solve] function:
 //! ```
-//! use sudokugen::solve;
 //! # use sudokugen::Board;
 //! #
-//! # let board: Board =
+//! # let mut board: Board =
 //! #    ". . . | 4 . . | 8 7 .
 //! #     4 . 3 | . . . | . . .
 //! #     2 . . | . . 3 | . . 9
@@ -47,22 +47,23 @@
 //! #    "
 //! #       .parse()
 //! #       .unwrap();
-//!
+//! #
+//! board.solve().unwrap();
 //! assert_eq!(
-//!     solve(&board).unwrap(),
+//!     board,
 //!     "695412873413879526287653419146235987728946135359187264561398742872564391934721658"
 //!     .parse()
 //!     .unwrap()
 //! );
 //! ```
 //!
-//! Finally you can generate new puzzles using [`generate`], the parameter `3` here indicates that
-//! you would like a puzzle of base size 3, which translates to a 9x9 puzzle.
+//! Finally you can generate new puzzles using [Puzzle::generate], when doing this you must specify what size of puzzle
+//! do you want to generate, [BoardSize] makes that very easy.
 //!
 //! ```
-//! use sudokugen::generate;
+//! use sudokugen::{Puzzle, BoardSize};
 //!
-//! let puzzle = generate(3);
+//! let puzzle = Puzzle::generate(BoardSize::NineByNine);
 //!
 //! println!("Puzzle\n{}", puzzle.board());
 //! println!("Solution\n{}", puzzle.solution());
@@ -95,8 +96,8 @@
 //!
 //! # Crate Layout
 //! This crate is divided in three modules. [`board`] contains the tools needed to parse, manipulate and print
-//! a puzzle and it's individual cells. [`solver`] contains the [`solve`] function and [`generator`] contains
-//! the [`generate`] function as well as an umbrella struct to hold the puzzle and it's solution.
+//! a puzzle and it's individual cells. [`solver`] extends [`board::Board`] with the [`board::Board::solve`] function and [`solver::generator`] contains
+//! the [Puzzle] structure and it's static [`Puzzle::generate`] function.
 //!
 //! # Puzzle quality
 //! Grading puzzles is beyond the scope of this crate. The reason behind it is that grading puzzles
@@ -107,22 +108,15 @@
 //! on the harder side of most generally available puzzles.
 //!
 //! # Is it fast?
-//! The quick answer is, it depends on your use case. The [`solve`] function is optimized to be
+//! The quick answer is, it depends on your use case. The [`Board::solve`] function is optimized to be
 //! decently fast for a 9x9 sudoku puzzle, in my 2017 MacBook Pro it takes an average of 300μs
 //! to solve a difficult puzzle, that is around 3000 puzzles per second.
 //!
-//! The [`generate`] function is less optimized and makes heavy usage of [`solve`] without trying to
+//! The [`Puzzle::generate`] function is less optimized and makes heavy usage of [`Board::solve`] without trying to
 //! re-use repeated computations, as such it's much slower clocking at about 18ms to generate
 //! a new puzzle in my benchmarks.
 //!
 //! You can run your own benchmarks with `cargo bench`
-//!
-//! [`solve`]: solver/fn.solve.html
-//! [`solver`]: solver/index.html
-//! [`generate`]: solver/generator/fn.generate.html
-//! [`generator`]: solver/generator/index.html
-//! [`Board`]: board/struct.Board.html
-//! [`board`]: board/index.html
 
 #![warn(missing_docs)]
 #![warn(missing_doc_code_examples)]
@@ -131,5 +125,5 @@ pub mod board;
 pub mod solver;
 
 pub use board::Board;
-pub use solver::generator::generate;
-pub use solver::solve;
+pub use board::BoardSize;
+pub use solver::generator::Puzzle;

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -162,14 +162,12 @@ impl SudokuSolver {
     fn new(board: &Board) -> Self {
         let candidate_cache = CandidateCache::from_board(&board);
 
-        let solver = SudokuSolver {
+        SudokuSolver {
             board: board.clone(),
             move_log: Vec::new(),
             candidate_cache,
             random: false,
-        };
-
-        solver
+        }
     }
 
     fn new_random(board: &Board) -> Self {
@@ -293,9 +291,9 @@ impl SudokuSolver {
 
         if let Ok(ref mut moves) = self.register_move(Strategy::Guess, &cell, value) {
             self.move_log.append(moves);
-            return Ok(());
+            Ok(())
         } else {
-            return self.backtrack().and(Ok(()));
+            self.backtrack().and(Ok(()))
         }
     }
 
@@ -384,7 +382,7 @@ impl SudokuSolver {
             }
         }
 
-        return Err(UnsolvableError);
+        Err(UnsolvableError)
     }
 }
 

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -3,10 +3,9 @@
 //! the solution, if there is one.
 //!
 //! ```
-//! use sudokugen::solver::solve;
 //! use sudokugen::board::Board;
 //!
-//! let board: Board =
+//! let mut board: Board =
 //!     ". . . | 4 . . | 8 7 .
 //!      4 . 3 | . . . | . . .
 //!      2 . . | . . 3 | . . 9
@@ -22,8 +21,9 @@
 //!        .parse()
 //!        .unwrap();
 //!
+//! board.solve().unwrap();
 //! assert_eq!(
-//!     solve(&board).unwrap(),
+//!     board,
 //!     "695412873413879526287653419146235987728946135359187264561398742872564391934721658"
 //!     .parse()
 //!     .unwrap()
@@ -74,9 +74,9 @@ impl MoveLog {
         }
     }
 
-    fn get_strategy(&self) -> Option<Strategy> {
+    fn get_strategy(&self) -> Strategy {
         match self {
-            Self::SetValue { strategy, .. } => Some(*strategy),
+            Self::SetValue { strategy, .. } => *strategy,
         }
     }
 }
@@ -100,77 +100,78 @@ impl error::Error for UnsolvableError {
 }
 
 #[derive(Debug)]
-struct SudokuSolver {
-    board: Board,
+struct SudokuSolver<'a> {
+    board: &'a mut Board,
     candidate_cache: CandidateCache,
     move_log: Vec<MoveLog>,
     random: bool,
 }
 
-/// Helper function to solve a sudoku puzzle.
-///
-/// Given a reference to a [`board`], this function returns a new [`board`] representing
-/// a solution to that sudoku puzzle.
-///
-/// ```
-/// use sudokugen::solver::solve;
-/// use sudokugen::board::Board;
-///
-/// let board: Board =
-///     ". . . | 4 . . | 8 7 .
-///      4 . 3 | . . . | . . .
-///      2 . . | . . 3 | . . 9
-///      ---------------------
-///      . . 6 | 2 . . | . . 7
-///      . . . | 9 . 6 | . . .
-///      3 . 9 | . 8 . | . . .
-///      ---------------------
-///      . . . | . . . | . 4 .
-///      8 7 2 | 5 . . | . . .
-///      . . . | 7 2 . | 6 . .
-///     "
-///        .parse()
-///        .unwrap();
-///
-/// assert_eq!(
-///     solve(&board).unwrap(),
-///     "695412873413879526287653419146235987728946135359187264561398742872564391934721658"
-///     .parse()
-///     .unwrap()
-/// );
-/// ```
-///
-/// If the puzzle has no possible solutions, this function returns [`UnsolvableError`].
-///
-/// ```
-/// # use sudokugen::solver::solve;
-/// # use sudokugen::board::Board;
-/// #
-/// let board = "123. ...4 .... ....".parse().unwrap();
-/// assert!(matches!(solve(&board), Err(UnsolvableError)));
-/// ```
-///
-/// [`board`]: ../board/struct.Board.html
-/// [`UnsolvableError`]: struct.UnsolvableError.html
-pub fn solve(board: &Board) -> Result<Board, UnsolvableError> {
-    let mut solver = SudokuSolver::new(board);
-    solver.solve()?;
-    Ok(solver.board)
+impl Board {
+    /// Solves the sudoku puzzle.
+    ///
+    /// Updates the current board with the solution to that sudoku puzzle.
+    ///
+    /// ```
+    /// use sudokugen::board::Board;
+    ///
+    /// let mut board: Board =
+    ///     ". . . | 4 . . | 8 7 .
+    ///      4 . 3 | . . . | . . .
+    ///      2 . . | . . 3 | . . 9
+    ///      ---------------------
+    ///      . . 6 | 2 . . | . . 7
+    ///      . . . | 9 . 6 | . . .
+    ///      3 . 9 | . 8 . | . . .
+    ///      ---------------------
+    ///      . . . | . . . | . 4 .
+    ///      8 7 2 | 5 . . | . . .
+    ///      . . . | 7 2 . | 6 . .
+    ///     "
+    ///        .parse()
+    ///        .unwrap();
+    ///
+    /// board.solve().unwrap();
+    ///
+    /// assert_eq!(
+    ///     board,
+    ///     "695412873413879526287653419146235987728946135359187264561398742872564391934721658"
+    ///     .parse()
+    ///     .unwrap()
+    /// );
+    /// ```
+    ///
+    /// If the puzzle has no possible solutions, this function returns [`UnsolvableError`].
+    ///
+    /// ```
+    /// # use sudokugen::board::Board;
+    /// #
+    /// let mut board: Board = "123. ...4 .... ....".parse().unwrap();
+    /// assert!(matches!(board.solve(), Err(UnsolvableError)));
+    /// ```
+    ///
+    /// [`board`]: ../board/struct.Board.html
+    /// [`UnsolvableError`]: struct.UnsolvableError.html
+    pub fn solve(&mut self) -> Result<(), UnsolvableError> {
+        let mut solver = SudokuSolver::new(self);
+        solver.solve()?;
+        Ok(())
+    }
 }
 
-impl SudokuSolver {
-    fn new(board: &Board) -> Self {
+impl<'a> SudokuSolver<'a> {
+    fn new(board: &'a mut Board) -> Self {
         let candidate_cache = CandidateCache::from_board(&board);
 
         SudokuSolver {
-            board: board.clone(),
+            board,
             move_log: Vec::new(),
             candidate_cache,
             random: false,
         }
     }
 
-    fn new_random(board: &Board) -> Self {
+    fn new_random(board: &'a mut Board) -> Self {
         let mut solver = Self::new(board);
         solver.random = true;
         solver
@@ -340,7 +341,7 @@ impl SudokuSolver {
             let strategy = mov.get_strategy();
             self.undo_move(mov);
 
-            if let Some(Strategy::Guess) = strategy {
+            if let Strategy::Guess = strategy {
                 // if possible values is not empty we need to try the remaining guesses
                 if !self
                     .candidate_cache
@@ -393,8 +394,7 @@ mod tests {
 
     #[test]
     fn naked_singles() {
-        let solver = SudokuSolver::new(
-            &"
+        let mut board = "
         12345678.
         2........
         3........
@@ -405,9 +405,10 @@ mod tests {
         8.....975
         ......13.
         "
-            .parse()
-            .unwrap(),
-        );
+        .parse()
+        .unwrap();
+
+        let solver = SudokuSolver::new(&mut board);
 
         let ns: HashSet<_> = solver.naked_singles().into_iter().collect();
         let res: HashSet<_> = vec![
@@ -423,8 +424,7 @@ mod tests {
 
     #[test]
     fn hidden_singles() {
-        let solver = SudokuSolver::new(
-            &"
+        let mut board = "
         ...45.78.
         9........
         .........
@@ -435,9 +435,10 @@ mod tests {
         .........
         .....9...
         "
-            .parse()
-            .unwrap(),
-        );
+        .parse()
+        .unwrap();
+
+        let solver = SudokuSolver::new(&mut board);
 
         assert_eq!(
             solver.hidden_singles(),
@@ -447,16 +448,15 @@ mod tests {
 
     #[test]
     fn hidden_singles_after_backtrack() {
-        let mut solver = SudokuSolver::new(
-            &"
+        let mut board = "
         ....
         3...
         ....
         ....
         "
-            .parse()
-            .unwrap(),
-        );
+        .parse()
+        .unwrap();
+        let mut solver = SudokuSolver::new(&mut board);
 
         let mut log = solver
             .register_move(Strategy::Guess, &solver.board.cell_at(3, 3), 3)
@@ -480,16 +480,16 @@ mod tests {
 
     #[test]
     fn register_move_results_in_error() {
-        let mut solver = SudokuSolver::new(
-            &"
-            12..
-            3...
-            ....
-            ....
-        "
-            .parse()
-            .unwrap(),
-        );
+        let mut board = "
+        12..
+        3...
+        ....
+        ....
+    "
+        .parse()
+        .unwrap();
+
+        let mut solver = SudokuSolver::new(&mut board);
 
         assert_eq!(
             solver

--- a/src/solver/generator.rs
+++ b/src/solver/generator.rs
@@ -13,8 +13,8 @@
 //! [`board`]: struct.GenSudoku.html#method.board
 //! [`solution`]: struct.GenSudoku.html#method.solution
 
-use super::{solve, MoveLog, Strategy, SudokuSolver};
-use crate::board::{Board, CellLoc};
+use super::{MoveLog, Strategy, SudokuSolver};
+use crate::board::{Board, BoardSize, CellLoc};
 use rayon::prelude::*;
 use std::collections::{BTreeSet, HashMap};
 
@@ -24,93 +24,117 @@ use std::collections::{BTreeSet, HashMap};
 /// a random board with a unique solution.
 ///
 /// [`generate`]: ../fn.generate.html
-pub struct GenSudoku {
+pub struct Puzzle {
     board: Board,
     solution: Board,
     guesses: HashMap<CellLoc, BTreeSet<u8>>,
 }
 
-/// Generate a new sudoku board with a unique solution.
-///
-/// The generate function creates a random board with a unique solution.
-/// It does this by "solving" the empty board using random guesses whenever
-/// it cannot find the correct solution. Once the empty board is solved,
-/// it iterates over each of the guesses and removes it if that guess is the
-/// only valid option for that cell.
-///
-/// ```
-/// use sudokugen::solver::generator::generate;
-///
-/// let puzzle = generate(3);
-///
-/// println!("{}", puzzle.board());
-/// println!("{}", puzzle.solution());
-/// ```
-pub fn generate(base_size: usize) -> GenSudoku {
-    let mut solver = SudokuSolver::new_random(&Board::new(base_size));
-    solver
-        .solve()
-        .expect("Should always be possible to solve an empty board");
-
-    let non_guesses = solver.move_log.iter().filter_map(|mov| match mov {
-        MoveLog::SetValue {
-            strategy: Strategy::Guess,
-            ..
-        } => None,
-        MoveLog::SetValue { cell, .. } => Some(cell),
-    });
-
-    let mut board = solver.board;
-
-    // remove every cell generated without guessing
-    for cell in non_guesses {
-        board.unset(cell);
-    }
-
-    let minimal_board = remove_false_guesses(board);
-    let mut solver = SudokuSolver::new(&minimal_board);
-    solver.solve().expect("A generated board must be solvable");
-    let givens: BTreeSet<CellLoc> = minimal_board
-        .iter_cells()
-        .filter(|cell| minimal_board.get(cell).is_some())
-        .collect();
-    let mut guesses = HashMap::new();
-    for mov in solver.move_log {
-        if let MoveLog::SetValue {
-            cell,
-            value,
-            strategy: Strategy::Guess,
-            undo_candidates,
-            ..
-        } = mov
-        {
-            if !givens.contains(&cell) {
-                let mut options = undo_candidates
-                    .alternative_options()
-                    .as_ref()
-                    .unwrap()
-                    .to_owned();
-                options.remove(&value);
-
-                guesses.insert(cell, options);
-            }
-        }
-    }
-
-    GenSudoku {
-        board: minimal_board,
-        solution: solver.board,
-        guesses,
+impl Board {
+    /// Generate a new sudoku board with a unique solution.
+    ///
+    /// This a utility function for generating a new puzzle when you don't care about the details,
+    /// it returns a new random board. It's equivalent to calling `Puzzle::generate(base_size).board().clone();`.
+    //. See the full generate documentation at [Puzzle::generate]
+    ///
+    /// ```
+    /// use sudokugen::{Board, BoardSize};
+    ///
+    /// let board = Board::generate(BoardSize::NineByNine);
+    ///
+    /// println!("{}", board);
+    /// ```
+    pub fn generate(board_size: BoardSize) -> Self {
+        Puzzle::generate(board_size).board
     }
 }
 
-impl GenSudoku {
+impl Puzzle {
+    /// Generate a new sudoku puzzle with a unique solution.
+    ///
+    /// The generate function creates a random board with a unique solution.
+    /// It does this by "solving" the empty board using random guesses whenever
+    /// it cannot find the correct solution. Once the empty board is solved,
+    /// it iterates over each of the guesses and removes it if that guess is the
+    /// only valid option for that cell.
+    ///
+    /// ```
+    /// use sudokugen::{Puzzle, BoardSize};
+    ///
+    /// let puzzle = Puzzle::generate(BoardSize::NineByNine);
+    ///
+    /// println!("{}", puzzle.board());
+    /// println!("{}", puzzle.solution());
+    /// ```
+    pub fn generate(board_size: BoardSize) -> Puzzle {
+        let mut board = Board::new(board_size);
+        let mut solver = SudokuSolver::new_random(&mut board);
+        solver
+            .solve()
+            .expect("Should always be possible to solve an empty board");
+
+        // dbg!(&solver.board.to_string());
+        let non_guesses = solver.move_log.iter().filter_map(|mov| match mov {
+            MoveLog::SetValue {
+                strategy: Strategy::Guess,
+                ..
+            } => None,
+            MoveLog::SetValue { cell, .. } => Some(cell),
+        });
+
+        // let mut board = solver.board;
+
+        // remove every cell generated without guessing
+        for cell in non_guesses {
+            board.unset(cell);
+        }
+
+        // let minimal_board = remove_false_guesses(board);
+        remove_false_guesses(&mut board);
+        let minimal_board = board;
+
+        let mut solved_board = minimal_board.clone();
+        let mut solver = SudokuSolver::new(&mut solved_board);
+        solver.solve().expect("A generated board must be solvable");
+        let givens: BTreeSet<CellLoc> = minimal_board
+            .iter_cells()
+            .filter(|cell| minimal_board.get(cell).is_some())
+            .collect();
+        let mut guesses = HashMap::new();
+        for mov in solver.move_log {
+            if let MoveLog::SetValue {
+                cell,
+                value,
+                strategy: Strategy::Guess,
+                undo_candidates,
+                ..
+            } = mov
+            {
+                if !givens.contains(&cell) {
+                    let mut options = undo_candidates
+                        .alternative_options()
+                        .as_ref()
+                        .unwrap()
+                        .to_owned();
+                    options.remove(&value);
+
+                    guesses.insert(cell, options);
+                }
+            }
+        }
+
+        Self {
+            board: minimal_board,
+            solution: solved_board,
+            guesses,
+        }
+    }
     /// Returns the minimal board generated
     ///
     /// ```
-    /// use sudokugen::generate;
+    /// use sudokugen::{Puzzle, BoardSize};
     ///
-    /// let gen = generate(3);
+    /// let gen = Puzzle::generate(BoardSize::NineByNine);
     /// println!("{}", gen.board());
     /// ```
     pub fn board(&self) -> &Board {
@@ -120,9 +144,9 @@ impl GenSudoku {
     /// Returns the solution for the generated board
     ///
     /// ```
-    /// use sudokugen::generate;
+    /// use sudokugen::{Puzzle, BoardSize};
     ///
-    /// let gen = generate(3);
+    /// let gen = Puzzle::generate(BoardSize::NineByNine);
     /// println!("{}", gen.solution());
     /// ```
     pub fn solution(&self) -> &Board {
@@ -132,48 +156,56 @@ impl GenSudoku {
     /// Verify that the solution for the generated board is unique.
     ///
     /// ```
-    /// use sudokugen::generate;
+    /// use sudokugen::{Puzzle, BoardSize};
     ///
-    /// let gen = generate(3);
+    /// let gen = Puzzle::generate(BoardSize::NineByNine);
     /// assert!(gen.is_solution_unique());
     /// ```
     pub fn is_solution_unique(&self) -> bool {
         for (cell, options) in self.guesses.iter() {
-            if options.par_iter().any(|value| {
+            let has_other_solutions = options.par_iter().any(|value| {
                 let mut board = self.board.clone();
                 board.set(cell, *value);
-                solve(&board).is_ok()
-            }) {
+                board.solve().is_ok()
+            });
+
+            if has_other_solutions {
                 return false;
             }
         }
 
-        return true;
+        true
     }
 }
 
-fn remove_false_guesses(board: Board) -> Board {
-    let mut cur_board = board.clone();
+fn remove_false_guesses(board: &mut Board) {
+    // let mut cur_board = board.clone();
 
-    for cell in board.iter_cells().filter(|cell| board.get(&cell).is_some()) {
-        let mut board = cur_board.clone();
+    let cells: Vec<_> = board
+        .iter_cells()
+        .filter(|cell| board.get(&cell).is_some())
+        .collect();
+
+    for cell in cells {
+        // let mut board = cur_board.clone();
 
         // this unidiomatic and slightly fragile rust is necessary to avoid cloning
         // the board on every loop run
-        let value = board.unset(&cell).expect("Guarateed by the loop above");
+        let value = board.unset(&cell).expect("Guaranteed by the loop above");
         let mut possible_values = cell
-            .get_possible_values(&board)
+            .get_possible_values(board)
             .expect("Guaranteed to be Some by the for loop");
         possible_values.remove(&value);
 
-        if possible_values.par_iter().all(|value| {
-            let mut board = board.clone();
-            board.set(&cell, *value);
-            solve(&board).is_err()
-        }) {
-            cur_board = board;
+        let is_guess = possible_values.par_iter().any(|other_value| {
+            let mut new_board = board.clone();
+            new_board.set(&cell, *other_value);
+            new_board.solve().is_ok()
+        });
+
+        if is_guess {
+            // board was solvable with a different value, this is a legitimate guess, reset it
+            board.set(&cell, value);
         }
     }
-
-    cur_board
 }

--- a/src/solver/indexed_map.rs
+++ b/src/solver/indexed_map.rs
@@ -108,8 +108,8 @@ impl<K: Indexed, V: Clone + Default> Map<K, V> for IndexedMap<K, V> {
         }
 
         if let Some(Some(_)) = self.keys.get(idx) {
-            let old_val = std::mem::take(&mut self.values[idx]);
-            self.values[idx] = value;
+            let old_val = std::mem::replace(&mut self.values[idx], value);
+
             self.keys[idx] = Some(key);
             Some(old_val)
         } else {
@@ -125,7 +125,7 @@ impl<K: Indexed, V: Clone + Default> Map<K, V> for IndexedMap<K, V> {
             panic!("Index out of bounds, index value for key is bigger than the map capacity.");
         }
 
-        if let Some(_) = self.keys[idx] {
+        if self.keys[idx].is_some() {
             self.keys[idx] = None;
             return Some(std::mem::take(&mut self.values[idx]));
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,16 +1,16 @@
-use sudokugen::board::Board;
-use sudokugen::generate;
-use sudokugen::solver::solve;
+use sudokugen::{Board, Puzzle};
 
 #[test]
 fn solve_sudoku_simple() {
-    let table: Board =
+    let mut table: Board =
         "...4..87.4.3......2....3..9..62....7...9.6...3.9.8...........4.8725........72.6.."
             .parse()
             .unwrap();
 
+    table.solve().unwrap();
+
     assert_eq!(
-        solve(&table).unwrap(),
+        table,
         "695412873413879526287653419146235987728946135359187264561398742872564391934721658"
             .parse()
             .unwrap()
@@ -19,13 +19,14 @@ fn solve_sudoku_simple() {
 
 #[test]
 fn solve_sudoku_with_backtrack() {
-    let table: Board =
+    let mut table: Board =
         ".724..3........49.........2921...5.7..4.6...3......2...4..7.....3..196....5..4.21"
             .parse()
             .unwrap();
 
+    table.solve().unwrap();
     assert_eq!(
-        solve(&table).unwrap(),
+        table,
         "572491386318726495469583172921348567754962813683157249146275938237819654895634721"
             .parse()
             .unwrap()
@@ -34,7 +35,7 @@ fn solve_sudoku_with_backtrack() {
 
 #[test]
 fn test_solved() {
-    let board: Board = "
+    let mut board: Board = "
     1 2 3 4 5 6 7 8 9
     1 2 3 4 5 6 7 8 9
     1 2 3 4 5 6 7 8 9
@@ -48,10 +49,10 @@ fn test_solved() {
     .parse()
     .unwrap();
 
-    let solved = solve(&board).unwrap();
+    board.solve().unwrap();
 
     assert_eq!(
-        solved,
+        board,
         "
     1 2 3 4 5 6 7 8 9
     1 2 3 4 5 6 7 8 9
@@ -70,15 +71,17 @@ fn test_solved() {
 
 #[test]
 fn generate_test() {
-    let gen = generate(3);
+    let puzzle = Puzzle::generate(sudokugen::board::BoardSize::NineByNine);
+    let board = puzzle.board();
+
     println!(
         "Final board ({})\n{}",
-        gen.board()
+        board
             .iter_cells()
-            .filter(|cell| gen.board().get(cell).is_some())
+            .filter(|cell| board.get(cell).is_some())
             .count(),
-        gen.board(),
+        board,
     );
 
-    assert!(gen.is_solution_unique());
+    assert!(puzzle.is_solution_unique());
 }


### PR DESCRIPTION
Simplifies sudokugen API, makes it more rusty

- move `solve` into the `Board` structure
- create a `Puzzle` structure for holding the result of `generate`
- generate becomes a static function of `Puzzle`
- board size is now controlled by an enum, rather than an arbitrary `usize`
- update benchmark to exclude cloning from the generate benchmark
- update documentation to make use of auto linking to symbols inside the crate